### PR TITLE
Add button to allow downloads in different formats

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "vue": "^2.6.10",
     "vue-codemirror": "^4.0.6",
     "vue-router": "^3.1.3",
+    "vue-select": "^3.2.0",
     "vue2-dropzone": "^3.6.0",
     "vuex": "^3.1.1"
   },

--- a/src/components/Fit.vue
+++ b/src/components/Fit.vue
@@ -6,18 +6,30 @@
         :options="cmOptions"
         :value="geojson"
       ></codemirror>
-      <p>
-        <a
-          class="btn"
-          v-bind:href="buttonDownload.href"
-          v-bind:download="buttonDownload.download"
-          type="button"
-          @click="download"
-          >DOWNLOAD</a
-        >
+      <div>
+        <div class="btn-download">
+          <a
+            class="btn btn-dropdown--first"
+            v-bind:href="buttonDownload.href"
+            v-bind:download="buttonDownload.download"
+            type="button"
+            @click="download"
+            >DOWNLOAD</a
+          >
+
+          <v-select
+            class="select__toggle--only btn-dropdown--last"
+            v-model="selectedFormat"
+            :options="fileFormats"
+            :clearable="false"
+            :searchable="false"
+            :reduce="format => format.value"
+            @input="download">
+          </v-select>
+        </div>
         &nbsp; or
         <a class="link" @click="refresh">Upload new file</a>
-      </p>
+      </div>
     </div>
     <div class="content" v-else>
       <vue-dropzone
@@ -54,12 +66,15 @@ import { codemirror } from 'vue-codemirror'
 import 'codemirror/lib/codemirror.css'
 import 'codemirror/theme/base16-light.css'
 
+import vSelect from 'vue-select'
+
 export default {
   data() {
     return {
       status: 'Select your FIT or GPX file',
       filename: '',
       geojson: '',
+      selectedFormat: 'geojson',
       buttonDownload: {
         href: '',
         download: 'download.geojson'
@@ -76,12 +91,20 @@ export default {
         mode: 'text/javascript',
         lineNumbers: true,
         line: true
-      }
+      },
+      fileFormats: [{
+        value: 'geojson',
+        label: 'Geojson'
+      }, {
+        value: 'csv',
+        label: 'CSV'
+      }]
     }
   },
   components: {
     vueDropzone: vueDropzone,
-    codemirror: codemirror
+    codemirror: codemirror,
+    vSelect: vSelect
   },
   methods: {
     get_gpx_data(node, result) {
@@ -331,6 +354,8 @@ export default {
 </script>
 
 <style lang="scss">
+@import "vue-select/src/scss/vue-select.scss";
+
 .container {
   width: 100%;
   height: 100%;
@@ -376,6 +401,63 @@ export default {
       z-index: -1;
       opacity: 0;
     }
+  }
+}
+
+.btn-download {
+  display: inline-flex;
+
+  .btn {
+    margin: 0;
+  }
+
+  .btn-dropdown--first {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+
+    border-right: 1px solid #fff;
+  }
+
+  .btn-dropdown--last {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    padding-right: 8px;
+    padding-left: 8px;
+  }
+}
+
+.v-select {
+  font-size: 14px;
+  line-height: normal;
+  color: #fff;
+  background-color: #42b983;
+  border-radius: 4px;
+
+  &.select__toggle--only {
+    padding: 0;
+
+    .vs__dropdown-toggle {
+      height: 100%;
+      border: none;
+      width: 100;
+      padding: 8px;
+    }
+
+    .vs__actions {
+      padding: 0;
+    }
+
+    .vs__dropdown-menu {
+      top: calc(-100% - 20px);
+      border: 1px solid rgba(0, 0, 0, 0.25);
+      border-radius: 4px;
+      min-width: initial;
+      width: initial;
+    }
+  }
+
+  .vs__selected-options {
+    display: none;
   }
 }
 

--- a/src/components/Fit.vue
+++ b/src/components/Fit.vue
@@ -24,7 +24,8 @@
             :clearable="false"
             :searchable="false"
             :reduce="format => format.value"
-            @input="download">
+            @input="download"
+          >
           </v-select>
         </div>
         &nbsp; or
@@ -92,13 +93,16 @@ export default {
         lineNumbers: true,
         line: true
       },
-      fileFormats: [{
-        value: 'geojson',
-        label: 'Geojson'
-      }, {
-        value: 'csv',
-        label: 'CSV'
-      }]
+      fileFormats: [
+        {
+          value: 'geojson',
+          label: 'Geojson'
+        },
+        {
+          value: 'csv',
+          label: 'CSV'
+        }
+      ]
     }
   },
   components: {
@@ -354,7 +358,7 @@ export default {
 </script>
 
 <style lang="scss">
-@import "vue-select/src/scss/vue-select.scss";
+@import 'vue-select/src/scss/vue-select.scss';
 
 .container {
   width: 100%;


### PR DESCRIPTION
Here's the first iteration.
- Added a `selectedFormat` variable that defaults to `'geojson'`. Whenever the `download()` method gets called that variable can be checked and switch appropriately.
- Used `vue-select` for the dropdown but there were a few styles added and html changes for structure.