### PR TITLE
feat: minimal github action ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,12 @@
+name: ci
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
+      - run: npm install
+      - run: npm run lint


### PR DESCRIPTION
Minimal github action, will run lint. Can be extended to run tests when required.
e.g. by adding `-run: npm run test`
Issue #61 