### PR TITLE
Add .env in .gitignore file [Fix for #96]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 /download.json
 
 # local env files
+.env
 .env.local
 .env.*.local
 


### PR DESCRIPTION
## issue
Previously .env file of local is also pushed to remote repo, which should not be pushed to remote

## usage changes
Add .env in .gitignore so that changes in .env won't be pushed to remote repo